### PR TITLE
Print the backtrace when job execution fails

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -84,7 +84,7 @@ class JobExecution
   end
 
   def error!(exception)
-    message = "JobExecution failed: #{exception.message}\n#{exception.backtrace}"
+    message = "JobExecution failed: #{exception.message}\n#{exception.backtrace.join("\n")}"
 
     if !exception.is_a?(Samson::Hooks::UserError)
       Airbrake.notify(exception,

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -84,7 +84,7 @@ class JobExecution
   end
 
   def error!(exception)
-    message = "JobExecution failed: #{exception.message}"
+    message = "JobExecution failed: #{exception.message}\n#{exception.backtrace}"
 
     if !exception.is_a?(Samson::Hooks::UserError)
       Airbrake.notify(exception,


### PR DESCRIPTION
This is helpful when trying to debug an error
