### PR TITLE
Update Bundler platforms 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,6 +432,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.6)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -631,6 +633,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-18
+  x86_64-linux
 
 DEPENDENCIES
   active_hash

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,6 +430,8 @@ GEM
     nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.6)
@@ -629,6 +631,7 @@ GEM
       multipart-post (~> 2.0)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,8 +430,6 @@ GEM
     nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.4-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.6)
@@ -632,7 +630,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-18
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
For less compilation during the `bundle install` process, add the `x86_64-linux` Bundler platform.

Also update the macOS platform to latest for local development.
